### PR TITLE
fm-api: fix bug on get_phys_port_state command cci request creation

### DIFF
--- a/src/cxlmi/commands.c
+++ b/src/cxlmi/commands.c
@@ -1784,7 +1784,7 @@ CXLMI_EXPORT int cxlmi_cmd_fmapi_get_phys_port_state(struct cxlmi_endpoint *ep,
 	if (!req)
 		return -1;
 
-	arm_cci_request(ep, req, sizeof(*req_pl),
+	arm_cci_request(ep, req, sizeof(*req_pl) + in->num_ports,
 			PHYSICAL_SWITCH, GET_PHYSICAL_PORT_STATE);
 	req_pl = (struct cxlmi_cmd_fmapi_get_phys_port_state_req *)req->payload;
 


### PR DESCRIPTION
The payload size is missing the number of ports in bytes. Ref: Get Physical Port State (Opcode 5101h) command, CXL spec 3.1 section 7.6.7.1.2.