### PR TITLE
fm-api: Add get virtual cxl switch info command support

### DIFF
--- a/src/cxlmi/api-types.h
+++ b/src/cxlmi/api-types.h
@@ -596,6 +596,35 @@ struct cxlmi_cmd_fmapi_get_domain_validation_sv_rsp {
 	uint8_t secret_value_uuid[0x10];
 } __attribute__((packed));
 
+/* CXL r3.1 Section 7.6.7.2.1: Get Virtual CXL switch Info (Opcode 5200h) */
+struct cxlmi_cmd_fmapi_get_virtual_cxl_switch_info_req {
+	uint8_t start_vppb;
+	uint8_t vppb_list_limit;
+	uint8_t num_vcs;
+	uint8_t vcs_ids[];
+} __attribute__((packed));
+
+struct cxlmi_cmd_fmapi_vppb_info {
+	uint8_t vppb_binding_status;
+	uint8_t vppb_bound_port_id;
+	uint8_t vppb_bound_ld_id;
+	uint8_t rsv1;
+} __attribute__((packed));
+
+struct cxlmi_cmd_fmapi_vcs_info_block {
+	uint8_t vcs_id;
+	uint8_t vcs_state;
+	uint8_t usp_id;
+	uint8_t num_vppbs;
+	struct cxlmi_cmd_fmapi_vppb_info vppbs[];
+} __attribute__((packed));
+
+struct cxlmi_cmd_fmapi_get_virtual_cxl_switch_info_rsp {
+	uint8_t num_vcs;
+	uint8_t rsv1[3];
+	struct cxlmi_cmd_fmapi_vcs_info_block vcs_info[];
+} __attribute__((packed));
+
 /* CXL r3.1 Section 7.6.7.2.2: BindvPPB (Opcode 5201h) */
 struct cxlmi_cmd_fmapi_bind_vppb {
 	uint8_t vcs_id;

--- a/src/cxlmi/commands.c
+++ b/src/cxlmi/commands.c
@@ -2032,8 +2032,10 @@ CXLMI_EXPORT int cxlmi_cmd_fmapi_get_virtual_cxl_switch_info(struct cxlmi_endpoi
 	ssize_t req_sz, rsp_sz, rsp_sz_min;
 	int i, rc = -1;
 
-	// Below two checks, currently limit the user on the requested number of vcs and vppbs_per_vcs,
-	// so that the response message payload does not exceed 1024 bytes in size as stated per DSP0234.
+	/*
+	* Below two checks, currently limit the user on the requested number of vcs and vppbs_per_vcs,
+	* so that the response message payload does not exceed 1024 bytes in size as stated per DSP0234.
+	*/
 
 	if (in->vppb_list_limit < 1 || in->vppb_list_limit > MAX_VPPBS_PER_VCS)
 		return rc;
@@ -2056,9 +2058,11 @@ CXLMI_EXPORT int cxlmi_cmd_fmapi_get_virtual_cxl_switch_info(struct cxlmi_endpoi
 	for (i = 0; i < in->num_vcs; i++)
 		req_pl->vcs_ids[i] = in->vcs_ids[i];
 
+	/* The user allocated buffer for the response payload, passed in as ret, should be minimum of rsp_pl_sz */
 	size_t vcs_info_block_max_sz = sizeof(struct cxlmi_cmd_fmapi_vcs_info_block) + in->vppb_list_limit * sizeof(struct cxlmi_cmd_fmapi_vppb_info);
 	size_t rsp_pl_sz = sizeof(*rsp_pl) + in->num_vcs * vcs_info_block_max_sz;
 	rsp_sz = sizeof(*rsp) + rsp_pl_sz;
+
 	size_t vcs_info_block_min_sz = sizeof(struct cxlmi_cmd_fmapi_vcs_info_block) + sizeof(struct cxlmi_cmd_fmapi_vppb_info);
 	size_t rsp_pl_min_sz = sizeof(*rsp_pl) + vcs_info_block_min_sz;
 	rsp_sz_min = sizeof(*rsp) + rsp_pl_min_sz;
@@ -2101,7 +2105,6 @@ CXLMI_EXPORT int cxlmi_cmd_fmapi_bind_vppb(struct cxlmi_endpoint *ep,
 	CXLMI_BUILD_BUG_ON(sizeof(*in) != 6);
 
 	req_sz = sizeof(*req_pl) + sizeof(*req);
-
 	req = calloc(1, req_sz);
 	if (!req)
 		return -1;

--- a/src/cxlmi/commands.c
+++ b/src/cxlmi/commands.c
@@ -2020,6 +2020,74 @@ CXLMI_EXPORT int cxlmi_cmd_fmapi_get_domain_validation_sv(struct cxlmi_endpoint 
 	return rc;
 }
 
+CXLMI_EXPORT int cxlmi_cmd_fmapi_get_virtual_cxl_switch_info(struct cxlmi_endpoint *ep,
+			    struct cxlmi_tunnel_info *ti,
+			    struct cxlmi_cmd_fmapi_get_virtual_cxl_switch_info_req *in,
+			    struct cxlmi_cmd_fmapi_get_virtual_cxl_switch_info_rsp *ret)
+{
+	struct cxlmi_cmd_fmapi_get_virtual_cxl_switch_info_req *req_pl;
+	struct cxlmi_cmd_fmapi_get_virtual_cxl_switch_info_rsp *rsp_pl;
+	_cleanup_free_ struct cxlmi_cci_msg *req = NULL;
+	_cleanup_free_ struct cxlmi_cci_msg *rsp = NULL;
+	ssize_t req_sz, rsp_sz, rsp_sz_min;
+	int i, rc = -1;
+
+	// Below two checks, currently limit the user on the requested number of vcs and vppbs_per_vcs,
+	// so that the response message payload does not exceed 1024 bytes in size as stated per DSP0234.
+
+	if (in->vppb_list_limit < 1 || in->vppb_list_limit > MAX_VPPBS_PER_VCS)
+		return rc;
+
+	if (in->num_vcs < 1 || in->num_vcs > MAX_VCS)
+		return rc;
+
+	req_sz = sizeof(*req_pl) + in->num_vcs + sizeof(*req);
+	req = calloc(1, req_sz);
+	if (!req)
+		return -1;
+
+    arm_cci_request(ep, req, sizeof(*req_pl) + in->num_vcs,
+			VIRTUAL_SWITCH, GET_VIRTUAL_CXL_SWITCH_INFO);
+	req_pl = (struct cxlmi_cmd_fmapi_get_virtual_cxl_switch_info_req *)req->payload;
+
+	req_pl->start_vppb = in->start_vppb;
+	req_pl->vppb_list_limit = in->vppb_list_limit;
+	req_pl->num_vcs = in->num_vcs;
+	for (i = 0; i < in->num_vcs; i++)
+		req_pl->vcs_ids[i] = in->vcs_ids[i];
+
+	size_t vcs_info_block_max_sz = sizeof(struct cxlmi_cmd_fmapi_vcs_info_block) + in->vppb_list_limit * sizeof(struct cxlmi_cmd_fmapi_vppb_info);
+	size_t rsp_pl_sz = sizeof(*rsp_pl) + in->num_vcs * vcs_info_block_max_sz;
+	rsp_sz = sizeof(*rsp) + rsp_pl_sz;
+	size_t vcs_info_block_min_sz = sizeof(struct cxlmi_cmd_fmapi_vcs_info_block) + sizeof(struct cxlmi_cmd_fmapi_vppb_info);
+	size_t rsp_pl_min_sz = sizeof(*rsp_pl) + vcs_info_block_min_sz;
+	rsp_sz_min = sizeof(*rsp) + rsp_pl_min_sz;
+
+	rsp = calloc(1, rsp_sz);
+	if (!rsp)
+		return -1;
+
+	rc = send_cmd_cci(ep, ti, req, req_sz, rsp, rsp_sz, rsp_sz_min);
+	if (rc)
+		return rc;
+
+	rsp_pl = (struct cxlmi_cmd_fmapi_get_virtual_cxl_switch_info_rsp *)rsp->payload;
+	memset(ret, 0, sizeof(*ret));
+
+	ret->num_vcs = rsp_pl->num_vcs;
+	for (i = 0; i < rsp_pl->num_vcs; i++) {
+		ret->vcs_info[i].vcs_id = rsp_pl->vcs_info[i].vcs_id;
+		ret->vcs_info[i].vcs_state = rsp_pl->vcs_info[i].vcs_state;
+		ret->vcs_info[i].usp_id = rsp_pl->vcs_info[i].usp_id;
+		ret->vcs_info[i].num_vppbs = rsp_pl->vcs_info[i].num_vppbs;
+		for (int j = 0; j < rsp_pl->vcs_info[i].num_vppbs; j++) {
+			ret->vcs_info[i].vppbs[j] = rsp_pl->vcs_info[i].vppbs[j];
+		}
+	}
+
+	return rc;
+}
+
 CXLMI_EXPORT int cxlmi_cmd_fmapi_bind_vppb(struct cxlmi_endpoint *ep,
 			    struct cxlmi_tunnel_info *ti,
 			    struct cxlmi_cmd_fmapi_bind_vppb *in)
@@ -2033,6 +2101,7 @@ CXLMI_EXPORT int cxlmi_cmd_fmapi_bind_vppb(struct cxlmi_endpoint *ep,
 	CXLMI_BUILD_BUG_ON(sizeof(*in) != 6);
 
 	req_sz = sizeof(*req_pl) + sizeof(*req);
+
 	req = calloc(1, req_sz);
 	if (!req)
 		return -1;

--- a/src/cxlmi/cxlmi.c
+++ b/src/cxlmi/cxlmi.c
@@ -1034,6 +1034,7 @@ static bool cxlmi_cmd_is_fmapi(int cmdset)
 {
 	switch(cmdset) {
 	case PHYSICAL_SWITCH:
+	case VIRTUAL_SWITCH:
 	case TUNNEL:
 	case MHD:
 	case DCD_MANAGEMENT:

--- a/src/cxlmi/private.h
+++ b/src/cxlmi/private.h
@@ -255,7 +255,8 @@ enum {
 	#define SET_DOMAIN_VALIDATION_SV           0x5
 	#define GET_VCS_DOMAIN_VALIDATION_SV_STATE 0x6
 	#define GET_DOMAIN_VALIDATION_SV           0x7
-	VIRTUAL_SWITCH = 0x52,
+    VIRTUAL_SWITCH = 0x52,
+	#define GET_VIRTUAL_CXL_SWITCH_INFO     0x0
 	#define BIND_VPPB     0x1
 	#define UNBIND_VPPB   0x2
     TUNNEL = 0x53,

--- a/src/libcxlmi.h
+++ b/src/libcxlmi.h
@@ -592,6 +592,13 @@ int cxlmi_cmd_fmapi_get_domain_validation_sv(struct cxlmi_endpoint *ep,
 			struct cxlmi_tunnel_info *ti,
 			struct cxlmi_cmd_fmapi_get_domain_validation_sv_req *in,
 			struct cxlmi_cmd_fmapi_get_domain_validation_sv_rsp *ret);
+
+#define MAX_VPPBS_PER_VCS 32
+#define MAX_VCS 32
+int cxlmi_cmd_fmapi_get_virtual_cxl_switch_info(struct cxlmi_endpoint *ep,
+			struct cxlmi_tunnel_info *ti,
+			struct cxlmi_cmd_fmapi_get_virtual_cxl_switch_info_req *in,
+			struct cxlmi_cmd_fmapi_get_virtual_cxl_switch_info_rsp *ret);
 int cxlmi_cmd_fmapi_bind_vppb(struct cxlmi_endpoint *ep,
 			struct cxlmi_tunnel_info *ti,
 			struct cxlmi_cmd_fmapi_bind_vppb *in);


### PR DESCRIPTION
Add support for Get Virtual CXL switch Info (Opcode 5200h) command, CXL r3.1 Section 7.6.7.2.1.

Maximum number of vcs and maximum number of vppbs per vcs are set to max 32, based on what could be expected commonly on cxl switches. This also let the cci response payload message not to exceed 1024 bytes in size.